### PR TITLE
feat: Added Config Support for Specifying Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,17 @@ profiling:
       pattern_type: regex
       schema: public
       # Matches: customer_2024, order_2024, etc.
+    
+    # Multi-database profiling (optional database field)
+    # - table: users
+    #   schema: public
+    #   database: analytics_db  # Profile from analytics_db instead of source.database
+    # - pattern: "order_*"
+    #   schema: public
+    #   database: warehouse_db  # Profile matching tables from warehouse_db
+    # - select_schema: true
+    #   schema: analytics
+    #   database: production_db  # Profile all tables in analytics schema from production_db
   
   # Discovery options for pattern-based selection
   discovery_options:
@@ -797,6 +808,15 @@ profiling:
       exclude_schemas:
         - "information_schema"
         - "pg_catalog"
+    
+    # Multi-database profiling (optional database field)
+    # When database is specified, the pattern operates on that database
+    # When omitted, uses config.source.database (backward compatible)
+    # - table: customers
+    #   schema: public
+    #   database: analytics_db
+    # - select_all_schemas: true
+    #   database: staging_db  # Profile all schemas in staging_db
     
     # Tag-based selection
     - tags:

--- a/baselinr/config/schema.py
+++ b/baselinr/config/schema.py
@@ -120,8 +120,14 @@ class TablePattern(BaseModel):
     - Tag-based (tags/tags_any fields)
 
     All methods can be combined with additional filters.
+
+    When database is specified, the pattern operates on that database.
+    When omitted, uses config.source.database (backward compatible).
     """
 
+    database: Optional[str] = Field(
+        None, description="Database name (optional, defaults to source.database)"
+    )
     schema_: Optional[str] = Field(None, alias="schema")
     table: Optional[str] = Field(
         None, description="Explicit table name (required if pattern not used)"

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -52,6 +52,17 @@ profiling:
     #     - "*_backup"
     #   # Uncomment to profile all tables in analytics schema
     
+    # Example: Multi-database profiling
+    # - table: users
+    #   schema: public
+    #   database: analytics_db  # Profile from analytics_db instead of source.database
+    # - pattern: "order_*"
+    #   schema: public
+    #   database: warehouse_db  # Profile matching tables from warehouse_db
+    # - select_schema: true
+    #   schema: analytics
+    #   database: production_db  # Profile all tables in analytics schema from production_db
+    
     # Example with partition-aware profiling (commented out)
     # - table: orders
     #   schema: public

--- a/examples/config_patterns.yml
+++ b/examples/config_patterns.yml
@@ -102,6 +102,16 @@ profiling:
         - "*_dev"
       # Profile all tables in all schemas (except excluded), excluding test/dev tables
     
+    # Example 4b: Multi-database profiling
+    # - table: customers
+    #   schema: public
+    #   database: analytics_db  # Profile from analytics_db
+    # - pattern: "sales_*"
+    #   schema: public
+    #   database: warehouse_db  # Profile matching tables from warehouse_db
+    # - select_all_schemas: true
+    #   database: staging_db  # Profile all schemas in staging_db
+    
     # Example 5: Tag-based selection (Snowflake example)
     # - tags:
     #     - "data_quality:critical"

--- a/tests/test_database_field.py
+++ b/tests/test_database_field.py
@@ -1,0 +1,243 @@
+"""
+Tests for database field functionality in TablePattern.
+
+Verifies that the database field works correctly across all components:
+- Schema validation
+- Table key generation
+- State store operations
+- Planner expansion
+"""
+
+import pytest
+
+from baselinr.config.schema import (
+    BaselinrConfig,
+    ConnectionConfig,
+    ProfilingConfig,
+    StorageConfig,
+    TablePattern,
+)
+from baselinr.incremental.state import TableState, TableStateStore
+from baselinr.planner import PlanBuilder
+
+
+class TestDatabaseFieldSchema:
+    """Tests for database field in TablePattern schema."""
+
+    def test_database_field_optional(self):
+        """Test that database field is optional (backward compatible)."""
+        pattern = TablePattern(table="users", schema="public")
+        assert pattern.database is None
+
+    def test_database_field_with_explicit_table(self):
+        """Test database field with explicit table."""
+        pattern = TablePattern(table="users", schema="public", database="analytics_db")
+        assert pattern.database == "analytics_db"
+        assert pattern.table == "users"
+        assert pattern.schema_ == "public"
+
+    def test_database_field_with_pattern(self):
+        """Test database field with pattern matching."""
+        pattern = TablePattern(pattern="user_*", schema="public", database="warehouse_db")
+        assert pattern.database == "warehouse_db"
+        assert pattern.pattern == "user_*"
+
+    def test_database_field_with_select_schema(self):
+        """Test database field with select_schema."""
+        pattern = TablePattern(select_schema=True, schema="analytics", database="production_db")
+        assert pattern.database == "production_db"
+        assert pattern.select_schema is True
+
+    def test_database_field_with_select_all_schemas(self):
+        """Test database field with select_all_schemas."""
+        pattern = TablePattern(select_all_schemas=True, database="staging_db")
+        assert pattern.database == "staging_db"
+        assert pattern.select_all_schemas is True
+
+
+class TestTableKeyGeneration:
+    """Tests for table key generation with database field."""
+
+    @pytest.fixture
+    def config(self):
+        """Create test configuration."""
+        return BaselinrConfig(
+            environment="test",
+            source=ConnectionConfig(type="postgres", database="default_db"),
+            storage=StorageConfig(
+                connection=ConnectionConfig(type="sqlite", database=":memory:", filepath=":memory:")
+            ),
+            profiling=ProfilingConfig(),
+        )
+
+    def test_table_key_without_database(self, config):
+        """Test table key generation without database (uses source.database)."""
+        builder = PlanBuilder(config)
+        pattern = TablePattern(table="users", schema="public")
+        key = builder._table_key(pattern)
+        # Should include source database
+        assert "default_db" in key
+        assert "public" in key
+        assert "users" in key
+
+    def test_table_key_with_database(self, config):
+        """Test table key generation with explicit database."""
+        builder = PlanBuilder(config)
+        pattern = TablePattern(table="users", schema="public", database="analytics_db")
+        key = builder._table_key(pattern)
+        assert "analytics_db" in key
+        assert "public" in key
+        assert "users" in key
+        assert key == "analytics_db.public.users"
+
+    def test_table_key_without_schema(self, config):
+        """Test table key generation without schema but with database."""
+        builder = PlanBuilder(config)
+        pattern = TablePattern(table="users", database="analytics_db")
+        key = builder._table_key(pattern)
+        assert "analytics_db" in key
+        assert "users" in key
+        assert key == "analytics_db.users"
+
+    def test_table_key_format(self, config):
+        """Test table key format is correct."""
+        builder = PlanBuilder(config)
+        
+        # Full: database.schema.table
+        pattern1 = TablePattern(table="users", schema="public", database="db1")
+        assert builder._table_key(pattern1) == "db1.public.users"
+        
+        # Without schema: database.table
+        pattern2 = TablePattern(table="users", database="db1")
+        assert builder._table_key(pattern2) == "db1.users"
+        
+        # Without database: source_db.schema.table
+        pattern3 = TablePattern(table="users", schema="public")
+        key3 = builder._table_key(pattern3)
+        assert key3.startswith("default_db")
+        assert "public.users" in key3 or key3 == "default_db.public.users"
+
+
+class TestStateStoreWithDatabase:
+    """Tests for state store operations with database field."""
+
+    @pytest.fixture
+    def state_store(self, tmp_path):
+        """Create test state store."""
+        storage_path = tmp_path / "state.db"
+        config = BaselinrConfig(
+            environment="test",
+            source=ConnectionConfig(type="postgres", database="test"),
+            storage=StorageConfig(
+                connection=ConnectionConfig(
+                    type="sqlite", database=str(storage_path), filepath=str(storage_path)
+                )
+            ),
+        )
+        return TableStateStore(
+            storage_config=config.storage,
+            table_name="test_state",
+            create_tables=True,
+        )
+
+    def test_table_state_key_with_database(self):
+        """Test TableState table_key property with database."""
+        state = TableState(
+            table_name="users",
+            schema_name="public",
+            database_name="analytics_db",
+        )
+        assert state.table_key == "analytics_db.public.users"
+
+    def test_table_state_key_without_database(self):
+        """Test TableState table_key property without database."""
+        state = TableState(table_name="users", schema_name="public")
+        assert state.table_key == "public.users"
+
+    def test_table_state_key_without_schema_or_database(self):
+        """Test TableState table_key property without schema or database."""
+        state = TableState(table_name="users")
+        assert state.table_key == "users"
+
+    def test_load_state_with_database(self, state_store):
+        """Test loading state with database field."""
+        # Create state with database
+        state = TableState(
+            table_name="users",
+            schema_name="public",
+            database_name="analytics_db",
+            snapshot_id="snapshot123",
+        )
+        state_store.upsert_state(state)
+
+        # Load state with database
+        loaded = state_store.load_state("users", "public", "analytics_db")
+        assert loaded is not None
+        assert loaded.database_name == "analytics_db"
+        assert loaded.table_name == "users"
+        assert loaded.schema_name == "public"
+
+    def test_load_state_without_database(self, state_store):
+        """Test loading state without database (backward compatible)."""
+        # Create state without database (None = source database)
+        state = TableState(
+            table_name="users",
+            schema_name="public",
+            snapshot_id="snapshot123",
+        )
+        state_store.upsert_state(state)
+
+        # Load state without database
+        loaded = state_store.load_state("users", "public", None)
+        assert loaded is not None
+        assert loaded.database_name is None
+        assert loaded.table_name == "users"
+
+    def test_record_decision_with_database(self, state_store):
+        """Test recording decision with database field."""
+        state_store.record_decision(
+            table_name="users",
+            schema_name="public",
+            decision="skip",
+            reason="no_changes",
+            snapshot_id="snapshot123",
+            database_name="analytics_db",
+        )
+
+        # Verify state was saved with database
+        loaded = state_store.load_state("users", "public", "analytics_db")
+        assert loaded is not None
+        assert loaded.database_name == "analytics_db"
+        assert loaded.decision == "skip"
+
+    def test_database_isolation(self, state_store):
+        """Test that states are isolated by database."""
+        # Create state in database1
+        state1 = TableState(
+            table_name="users",
+            schema_name="public",
+            database_name="db1",
+            snapshot_id="snapshot1",
+        )
+        state_store.upsert_state(state1)
+
+        # Create state in database2 with same table/schema
+        state2 = TableState(
+            table_name="users",
+            schema_name="public",
+            database_name="db2",
+            snapshot_id="snapshot2",
+        )
+        state_store.upsert_state(state2)
+
+        # Verify they are separate
+        loaded1 = state_store.load_state("users", "public", "db1")
+        loaded2 = state_store.load_state("users", "public", "db2")
+
+        assert loaded1 is not None
+        assert loaded2 is not None
+        assert loaded1.database_name == "db1"
+        assert loaded2.database_name == "db2"
+        assert loaded1.snapshot_id == "snapshot1"
+        assert loaded2.snapshot_id == "snapshot2"
+

--- a/tests/test_table_patterns.py
+++ b/tests/test_table_patterns.py
@@ -256,3 +256,30 @@ class TestTablePatternSchema:
         with pytest.raises(ValueError, match="pattern_type must be"):
             TablePattern(pattern="test", pattern_type="invalid")
 
+    def test_database_field(self):
+        """Test database field in TablePattern."""
+        # Explicit table with database
+        pattern = TablePattern(table="users", schema="public", database="analytics_db")
+        assert pattern.database == "analytics_db"
+        assert pattern.table == "users"
+        assert pattern.schema_ == "public"
+
+        # Pattern with database
+        pattern = TablePattern(pattern="user_*", schema="public", database="warehouse_db")
+        assert pattern.database == "warehouse_db"
+        assert pattern.pattern == "user_*"
+
+        # Schema selection with database
+        pattern = TablePattern(select_schema=True, schema="analytics", database="production_db")
+        assert pattern.database == "production_db"
+        assert pattern.select_schema is True
+
+        # Database-level selection with database (redundant but valid)
+        pattern = TablePattern(select_all_schemas=True, database="staging_db")
+        assert pattern.database == "staging_db"
+        assert pattern.select_all_schemas is True
+
+        # Database field is optional (backward compatible)
+        pattern = TablePattern(table="users", schema="public")
+        assert pattern.database is None
+

--- a/website/docs/reference/CONFIG_REFERENCE.md
+++ b/website/docs/reference/CONFIG_REFERENCE.md
@@ -275,6 +275,7 @@ Configuration options for table discovery and pattern-based selection.
 Configuration for a single table or table selection pattern.
 
 **Fields:**
+- `database` (Optional[str]): Database name (optional, defaults to `source.database`). When specified, the pattern operates on that database instead of the default source database. This enables multi-database profiling in a single configuration.
 - `table` (Optional[str]): Explicit table name (required if pattern not used)
 - `schema` (Optional[str]): Schema name (alias: `schema_`)
   
@@ -284,8 +285,8 @@ Configuration for a single table or table selection pattern.
 - `schema_pattern` (Optional[str]): Wildcard/regex pattern for schema names
   
   **Schema/database-level selection:**
-- `select_schema` (Optional[bool]): If `true`, profile all tables in specified schema(s)
-- `select_all_schemas` (Optional[bool]): If `true`, profile all schemas in database
+- `select_schema` (Optional[bool]): If `true`, profile all tables in specified schema(s). Can be combined with `database` field to profile all tables in a schema from a specific database.
+- `select_all_schemas` (Optional[bool]): If `true`, profile all schemas in database. Can be combined with `database` field to profile all schemas from a specific database.
   
   **Tag-based selection:**
 - `tags` (Optional[List[str]]): Tags that tables must have (AND logic)


### PR DESCRIPTION
## Summary

Adds optional `database` field to `TablePattern` to enable profiling tables across multiple databases in a single configuration. This addresses scalability limitations where the system previously assumed a single database connection, which doesn't scale for production environments with multiple databases.

## Problem

Previously, Baselinr only supported profiling tables from a single database specified in `config.source.database`. This limitation meant:

- Users couldn't profile tables with the same schema/table name across different databases
- Separate configurations or runs were required for each database
- Production systems with multiple databases (e.g., `analytics_db`, `staging_db`, `production_db`, `warehouse_db`) couldn't be managed efficiently

## Solution

Added an optional `database` field to `TablePattern` that allows specifying which database a pattern should operate on. When specified, the pattern uses that database; when omitted, it defaults to `config.source.database` (fully backward compatible).

## Changes

### Schema Updates
- Added `database: Optional[str]` field to `TablePattern` class
- Field is optional and defaults to `None` for backward compatibility
- Updated docstring to explain database field usage

### Planner Updates
- Added connector caching per database (`_connector_cache`)
- Updated `_get_connector()` to accept database parameter and create database-specific connectors
- Updated `_table_key()` to include database in key format: `database.schema.table`
- Updated all pattern expansion methods to support database:
  - `_expand_pattern()`
  - `_expand_database_level()`
  - `_expand_schema_level()`
  - `_expand_pattern_based()`
  - `_get_schemas_to_search()`
  - `_get_tables_in_schema()`

### State Store Updates
- Added `database_name: Optional[str]` field to `TableState`
- Updated `table_key` property to include database
- Added `database_name` column to state table (primary key component)
- Updated `load_state()`, `upsert_state()`, and `record_decision()` to handle database
- Ensures proper isolation between tables with same name/schema in different databases

### Incremental Planner Updates
- Added change detector caching per database (`_change_detector_cache`)
- Updated `_summarize_changes()` to use database-specific change detectors
- Updated `_decide_for_table()` and `_emit_skip()` to pass database to state store methods

### CLI Updates
- Updated `_plan_table_key()` and `_plan_table_key_raw()` to include database in key format
- Updated `_update_state_store_with_results()` to handle database when matching results to decisions

### Profiling Core Updates
- Added connector and metric calculator caching per database
- Updated `_profile_table()` to use database-specific connectors and metric calculators
- Updated `_get_row_count()` to accept connector parameter

### Documentation Updates
- Updated `examples/config.yml` with multi-database examples
- Updated `examples/config_patterns.yml` with multi-database examples
- Updated `README.md` with database field documentation
- Updated `website/docs/reference/CONFIG_REFERENCE.md` with database field specification

## Usage Examples

### Explicit Table with Database
```yaml
profiling:
  tables:
    - table: users
      schema: public
      database: analytics_db
```

### Pattern Matching with Database
```yaml
profiling:
  tables:
    - pattern: "order_*"
      schema: public
      database: warehouse_db
```

### Schema Selection with Database
```yaml
profiling:
  tables:
    - select_schema: true
      schema: analytics
      database: production_db
```

### Database-Level Selection with Database
```yaml
profiling:
  tables:
    - select_all_schemas: true
      database: staging_db
```

### Mixed Database Profiling
```yaml
profiling:
  tables:
    # Profile from analytics_db
    - table: customers
      schema: public
      database: analytics_db
    
    # Profile from warehouse_db
    - pattern: "sales_*"
      schema: public
      database: warehouse_db
    
    # Profile from default source.database
    - table: users
      schema: public
      # No database field = uses source.database
```

## Backward Compatibility

✅ **Fully backward compatible** - All existing configurations continue to work without modification:
- When `database` is `None` or omitted, patterns use `config.source.database` (original behavior)
- Existing state store rows without `database_name` are treated as source.database
- No breaking changes to existing APIs or configurations

## Testing

### New Tests Added
- `test_database_field.py` - Comprehensive test suite covering:
  - Schema validation with database field
  - Table key generation with database
  - State store operations with database
  - Database isolation in state store
- Updated `test_table_patterns.py` with database field validation tests

### Test Coverage
- ✅ Explicit table with database field
- ✅ Pattern matching with database field
- ✅ `select_schema` with database field
- ✅ `select_all_schemas` with database field
- ✅ Backward compatibility (no database field)
- ✅ State store with database field
- ✅ Table key generation with database
- ✅ Database isolation in state store

All existing tests continue to pass, confirming backward compatibility.

## Technical Details

### Connector Caching
- Connectors are cached per database to avoid recreating connections
- Cache key: `None` for source database, database name for explicit databases
- Reuses connections across patterns for the same database

### State Store Schema
- Primary key updated to: `(database_name, schema_name, table_name)`
- `database_name` is nullable for backward compatibility
- Existing rows: `database_name=None` represents source.database

### Table Key Format
- With database: `database.schema.table` or `database.table`
- Without database: `source_db.schema.table` or `source_db.table` or `schema.table`

## Migration Notes

No migration required! The changes are fully backward compatible:
- Existing configurations work without modification
- Existing state store data continues to work (treats `database_name=None` as source.database)
- New configurations can optionally use the `database` field
